### PR TITLE
removing exludes in Package.swift that are reporting warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # macOS
 .DS_Store
+.swiftpm
 
 # Xcode
 build/

--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,7 @@ let package = Package(
         .target(
             name: "MurmurHash_Swift",
             dependencies: [],
-            path: "Sources/MurmurHash/",
-            exclude: ["MurmurHash.xcodeproj", "README.md", "Sources/MurmurHash/Info.plist", "Sources/MurmurHash/MurmurHash.h"]),
+            path: "Sources/MurmurHash/"),
         .testTarget(
             name: "MurmurHashTests",
             dependencies: ["MurmurHash_Swift"]),


### PR DESCRIPTION
I tried to use it as a swift package within a new project using Xcode 13.1, and the build system reported all of the excludes that were included were invalid.

 - and adds `.swiftpm` to the .gitignore